### PR TITLE
Let subscribe process messages asynchronously

### DIFF
--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -640,7 +640,7 @@ class Client():
 
         msg = Msg(subject=subject.decode(), reply=reply.decode(), data=data)
         if sub.cb is not None:
-            yield from sub.cb(msg)
+            self._loop.create_task(sub.cb(msg))
         elif sub.future is not None and not sub.future.cancelled():
             sub.future.set_result(msg)
 


### PR DESCRIPTION
Reverts change introduced in
https://github.com/nats-io/asyncio-nats/blob/cdf2d3a05f735cf0db447ee72454078ee94349ee/nats/aio/client.py#L643
to let `subscribe` handling messages asynchronously.