### PR TITLE
Change `subscribe` coroutines to process messages sequentially, add `subscribe_async` alternative

### DIFF
--- a/benchmark/sub_async_await_perf.py
+++ b/benchmark/sub_async_await_perf.py
@@ -1,0 +1,96 @@
+import argparse, sys
+import asyncio
+import time
+from random import randint
+from nats.aio.client import Client as NATS
+from nats.aio.errors import ErrTimeout
+
+# NOTE: Only works in Python 3.5 or above since async/await
+# syntax is required.
+
+DEFAULT_FLUSH_TIMEOUT = 30
+DEFAULT_NUM_MSGS = 100000
+DEFAULT_MSG_SIZE = 16
+DEFAULT_BATCH_SIZE = 100
+HASH_MODULO = 1000
+
+def show_usage():
+    message = """
+Usage: sub_perf [options]
+
+options:
+    -n COUNT                         Messages to send (default: 100000}
+    -t SUBTYPE                       Subscription type to use. Valid choices are 'async','sync' (default: sync)
+    -S SUBJECT                       Send subject (default: (test)
+    """
+    print(message)
+
+def show_usage_and_die():
+    show_usage()
+    sys.exit(1)
+
+async def main(loop):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-n', '--count', default=DEFAULT_NUM_MSGS, type=int)
+    parser.add_argument('-S', '--subject', default='test')
+    parser.add_argument('-t', '--subtype', default='sync')
+    parser.add_argument('--servers', default=[], action='append')
+    args = parser.parse_args()
+
+    servers = args.servers
+    if len(args.servers) < 1:
+        servers = ["nats://127.0.0.1:4222"]
+    opts = { "servers": servers, "io_loop": loop, "allow_reconnect": False }
+
+    # Make sure we're connected to a server first...
+    nc = NATS()
+    try:
+        await nc.connect(**opts)
+    except Exception as e:
+        sys.stderr.write("ERROR: {0}".format(e))
+        show_usage_and_die()
+
+    received = 0
+    start = None
+
+    async def handler(msg):
+        nonlocal received
+        nonlocal start
+        received += 1
+
+        # Measure time from when we get the first message.
+        if received == 1:
+            start = time.monotonic()
+        if (received % HASH_MODULO) == 0:
+            sys.stdout.write("*")
+            sys.stdout.flush()
+
+    if args.subtype == 'sync':
+        await nc.subscribe(args.subject, cb=handler)
+    elif args.subtype == 'async':
+        await nc.subscribe_async(args.subject, cb=handler)
+    else:
+        sys.stderr.write("ERROR: Unsupported type of subscription {0}".format(e))
+        show_usage_and_die()
+
+    print("Waiting for {} messages on [{}]...".format(args.count, args.subject))
+    try:
+        # Additional roundtrip with server to ensure everything has been
+        # processed by the server already.
+        await nc.flush()
+    except ErrTimeout:
+        print("Server flush timeout after {0}".format(DEFAULT_FLUSH_TIMEOUT))
+
+    while received < args.count:
+        await asyncio.sleep(0.1, loop=loop)
+
+    elapsed = time.monotonic() - start
+    print("\nTest completed : {0} msgs/sec sent".format(args.count/elapsed))
+
+    print("Received {0} messages ({1} msgs/sec)".format(received, received/elapsed))
+    await nc.close()
+
+if __name__ == '__main__':
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(main(loop))
+    loop.close()

--- a/benchmark/sub_perf.py
+++ b/benchmark/sub_perf.py
@@ -17,6 +17,7 @@ Usage: sub_perf [options]
 
 options:
     -n COUNT                         Messages to send (default: 100000}
+    -t SUBTYPE                       Subscription type to use. Valid choices are 'async','sync' (default: sync)
     -S SUBJECT                       Send subject (default: (test)
     """
     print(message)
@@ -30,6 +31,7 @@ def main(loop):
     parser = argparse.ArgumentParser()
     parser.add_argument('-n', '--count', default=DEFAULT_NUM_MSGS, type=int)
     parser.add_argument('-S', '--subject', default='test')
+    parser.add_argument('-t', '--subtype', default='sync')
     parser.add_argument('--servers', default=[], action='append')
     args = parser.parse_args()
 
@@ -62,7 +64,13 @@ def main(loop):
             sys.stdout.write("*")
             sys.stdout.flush()
 
-    yield from nc.subscribe(args.subject, cb=handler)
+    if args.subtype == 'sync':
+        yield from nc.subscribe(args.subject, cb=handler)
+    elif args.subtype == 'async':
+        yield from nc.subscribe_async(args.subject, cb=handler)
+    else:
+        sys.stderr.write("ERROR: Unsupported type of subscription {0}".format(e))
+        show_usage_and_die()
 
     print("Waiting for {} messages on [{}]...".format(args.count, args.subject))
     try:

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -3,7 +3,6 @@
 import asyncio
 import json
 import time
-import functools
 from random import shuffle
 from datetime import datetime
 from urllib.parse import urlparse

--- a/tests/client_async_await_test.py
+++ b/tests/client_async_await_test.py
@@ -1,0 +1,62 @@
+import sys
+import asyncio
+import unittest
+
+from nats.aio.client import Client as NATS
+from tests.utils import (async_test, SingleServerTestCase)
+
+class ClientAsyncAwaitTest(SingleServerTestCase):
+
+  @async_test
+  def test_async_await_subscribe_async(self):
+    nc = NATS()
+    msgs = []
+
+    async def subscription_handler(msg):
+      if msg.subject == "tests.1":
+        await asyncio.sleep(0.5, loop=self.loop)
+      if msg.subject == "tests.3":
+        await asyncio.sleep(0.2, loop=self.loop)
+      msgs.append(msg)
+
+    yield from nc.connect(io_loop=self.loop)
+    sid = yield from nc.subscribe("tests.>", cb=subscription_handler)
+
+    for i in range(0, 5):
+      yield from nc.publish("tests.{}".format(i), b'bar')
+
+    # Wait a bit for messages to be received.
+    yield from asyncio.sleep(1, loop=self.loop)
+    self.assertEqual(5, len(msgs))
+    self.assertEqual("tests.1", msgs[1].subject)
+    self.assertEqual("tests.3", msgs[3].subject)
+    yield from nc.close()
+
+  @async_test
+  def test_async_await_subscribe_sync(self):
+    nc = NATS()
+    msgs = []
+
+    async def subscription_handler(msg):
+      if msg.subject == "tests.1":
+          await asyncio.sleep(0.5, loop=self.loop)
+      if msg.subject == "tests.3":
+          await asyncio.sleep(0.2, loop=self.loop)
+      msgs.append(msg)
+
+    yield from nc.connect(io_loop=self.loop)
+    sid = yield from nc.subscribe_async("tests.>", cb=subscription_handler)
+
+    for i in range(0, 5):
+      yield from nc.publish("tests.{}".format(i), b'bar')
+
+    # Wait a bit for messages to be received.
+    yield from asyncio.sleep(1, loop=self.loop)
+    self.assertEqual(5, len(msgs))
+    self.assertEqual("tests.1", msgs[4].subject)
+    self.assertEqual("tests.3", msgs[3].subject)
+    yield from nc.close()
+
+if __name__ == '__main__':
+  runner = unittest.TextTestRunner(stream=sys.stdout)
+  unittest.main(verbosity=2, exit=False, testRunner=runner)

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -261,6 +261,16 @@ class ClientTest(SingleServerTestCase):
     yield from nc.close()
 
   @async_test
+  def test_invalid_subscription_type(self):
+    nc = NATS()
+
+    with self.assertRaises(NatsError):
+      yield from nc.subscribe("hello", cb=None, future=None)
+
+    with self.assertRaises(NatsError):
+      yield from nc.subscribe_async("hello", cb=None)
+
+  @async_test
   def test_unsubscribe(self):
     nc = NATS()
     msgs = []

--- a/tests/test.py
+++ b/tests/test.py
@@ -4,12 +4,19 @@ import unittest
 from tests.parser_test import *
 from tests.client_test import *
 
+if sys.version_info >= (3, 5):
+    from tests.client_async_await_test import *
+
 if __name__ == '__main__':
     test_suite = unittest.TestSuite()
     test_suite.addTest(unittest.makeSuite(ProtocolParserTest))
     test_suite.addTest(unittest.makeSuite(ClientUtilsTest))
     test_suite.addTest(unittest.makeSuite(ClientTest))
     test_suite.addTest(unittest.makeSuite(ClientReconnectTest))
+
+    # Skip tests using async/await syntax unless on Python 3.5
+    if sys.version_info >= (3, 5):
+        test_suite.addTest(unittest.makeSuite(ClientAsyncAwaitTest))
     runner = unittest.TextTestRunner(stream=sys.stdout)
     result = runner.run(test_suite)
     if not result.wasSuccessful():


### PR DESCRIPTION
This makes the default `subscribe` method to process messages sequentially, and also adds another `subscribe_async` method which has the previous behavior and uses a task for processing the message.

This is a breaking change but necessary in order to allow to follow similar behavior in Go client and also making the option which shows higher performance throughput the default behavior.
