### PR TITLE
Reconnection logic fixes

### DIFF
--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -607,8 +607,6 @@ class Client(object):
             self._ping_interval_task.cancel()
 
         if self._flusher_task is not None and not self._flusher_task.cancelled():
-            if not self._flush_queue.empty():
-                self._flush_queue.task_done()
             self._flusher_task.cancel()
 
         if self._io_writer is not None:

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -10,7 +10,7 @@ from nats.aio.errors import *
 from nats.aio.utils import new_inbox
 from nats.protocol.parser import *
 
-__version__ = '0.3.3'
+__version__ = '0.4.0'
 __lang__ = 'python3'
 
 INFO_OP = b'INFO'

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -38,6 +38,8 @@ DEFAULT_PING_INTERVAL = 120  # in seconds
 DEFAULT_MAX_OUTSTANDING_PINGS = 2
 DEFAULT_MAX_PAYLOAD_SIZE = 1048576
 
+DEFAULT_MAX_FLUSHER_QUEUE_SIZE = 1024
+
 MAX_CONTROL_LINE_SIZE = 1024
 
 
@@ -141,7 +143,8 @@ class Client(object):
                 max_reconnect_attempts=DEFAULT_MAX_RECONNECT_ATTEMPTS,
                 ping_interval=DEFAULT_PING_INTERVAL,
                 max_outstanding_pings=DEFAULT_MAX_OUTSTANDING_PINGS,
-                dont_randomize=False):
+                dont_randomize=False,
+                flusher_queue_size=DEFAULT_MAX_FLUSHER_QUEUE_SIZE):
         self._setup_server_pool(servers)
         self._loop = io_loop or asyncio.get_event_loop()
         self._error_cb = error_cb
@@ -159,6 +162,9 @@ class Client(object):
         self.options["max_reconnect_attempts"] = max_reconnect_attempts
         self.options["ping_interval"] = ping_interval
         self.options["max_outstanding_pings"] = max_outstanding_pings
+
+        # Queue used to trigger flushes to the socket
+        self._flush_queue = asyncio.Queue(maxsize=flusher_queue_size, loop=self._loop)
 
         if self.options["dont_randomize"] is False:
             shuffle(self._server_pool)
@@ -488,8 +494,7 @@ class Client(object):
             self._pending.insert(0, cmd)
         else:
             self._pending.append(cmd)
-
-        self._pending_data_size += len(self._pending)
+        self._pending_data_size += len(cmd)
         if self._pending_data_size > DEFAULT_PENDING_SIZE:
             yield from self._flush_pending()
 
@@ -504,9 +509,6 @@ class Client(object):
 
         except asyncio.CancelledError:
             pass
-        except:
-            self._process_op_err(
-                NatsError("nats: error kicking the flusher"))
 
     def _setup_server_pool(self, servers):
         for server in servers:
@@ -588,20 +590,7 @@ class Client(object):
 
         if self.options["allow_reconnect"] and self.is_connected:
             self._status = Client.RECONNECTING
-
-            if self._reading_task is not None:
-                self._reading_task.cancel()
-
-            if self._ping_interval_task is not None:
-                self._ping_interval_task.cancel()
-
-            if self._io_writer is not None:
-                self._io_writer.close()
-
-            if self._flush_queue is not None:
-                if not self._flush_queue.empty():
-                    self._flush_queue.task_done()
-                self._flusher_task.cancel()
+            self._ps.reset()
 
             self._loop.create_task(self._attempt_reconnect())
         else:
@@ -611,6 +600,20 @@ class Client(object):
 
     @asyncio.coroutine
     def _attempt_reconnect(self):
+        if self._reading_task is not None and not self._reading_task.cancelled():
+            self._reading_task.cancel()
+
+        if self._ping_interval_task is not None and not self._ping_interval_task.cancelled():
+            self._ping_interval_task.cancel()
+
+        if self._flusher_task is not None and not self._flusher_task.cancelled():
+            if not self._flush_queue.empty():
+                self._flush_queue.task_done()
+            self._flusher_task.cancel()
+
+        if self._io_writer is not None:
+            self._io_writer.close()
+        
         self._err = None
         if self._disconnected_cb is not None:
             yield from self._disconnected_cb()
@@ -641,9 +644,7 @@ class Client(object):
                 # FIXME: Could use future here and wait for an error result
                 # to bail earlier in case there are errors in the connection.
                 yield from self._flush_pending()
-
                 self._status = Client.CONNECTED
-
                 yield from self.flush()
                 if self._reconnected_cb is not None:
                     yield from self._reconnected_cb()
@@ -655,7 +656,7 @@ class Client(object):
                 self._err = e
                 yield from self.close()
                 break
-            except (OSError, NatsError) as e:
+            except (OSError, NatsError, ErrTimeout) as e:
                 self._err = e
                 if self._error_cb is not None:
                     yield from self._error_cb(e)
@@ -799,8 +800,7 @@ class Client(object):
         self._pings_outstanding = 0
         self._ping_interval_task = self._loop.create_task(self._ping_interval())
 
-        # Queue for kicking the flusher
-        self._flush_queue = asyncio.Queue(maxsize=1024, loop=self._loop)
+        # Task for kicking the flusher queue
         self._flusher_task = self._loop.create_task(self._flusher())
 
     @asyncio.coroutine
@@ -830,12 +830,12 @@ class Client(object):
                     self._pending_data_size = 0
                     yield from self._io_writer.drain()
             except OSError as e:
+                if self._error_cb is not None:
+                    yield from self._error_cb(e)
                 self._process_op_err(e)
+                break
             except asyncio.CancelledError:
                 break
-            except:
-                self._process_op_err(
-                    NatsError("nats: error during flush"))
 
     @asyncio.coroutine
     def _ping_interval(self):
@@ -869,6 +869,8 @@ class Client(object):
                 if should_bail or self._io_reader is None:
                     break
                 if self.is_connected and self._io_reader.at_eof():
+                    if self._error_cb is not None:
+                        yield from self._error_cb(ErrStaleConnection)
                     self._process_op_err(ErrStaleConnection)
                     break
 

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -556,11 +556,13 @@ class ClientReconnectTest(MultiServerAuthTestCase):
       'servers': [
         "nats://foo:bar@127.0.0.1:4223",
         "nats://hoge:fuga@127.0.0.1:4224"
-        ],
+       ],
+      'dont_randomize': True,
       'io_loop': self.loop,
       'disconnected_cb': disconnected_cb,
       'closed_cb': closed_cb,
-      'reconnected_cb': reconnected_cb
+      'reconnected_cb': reconnected_cb,
+      'reconnect_time_wait': 0.01
       }
     yield from nc.connect(**options)
     largest_pending_data_size = 0
@@ -588,6 +590,92 @@ class ClientReconnectTest(MultiServerAuthTestCase):
     self.assertTrue(largest_pending_data_size > 0)
     self.assertTrue(post_flush_pending_data == 0)
 
+    # Confirm we have reconnected eventually
+    for i in range(0, 10):
+      yield from asyncio.sleep(0, loop=self.loop)
+      yield from asyncio.sleep(0.2, loop=self.loop)
+      yield from asyncio.sleep(0, loop=self.loop)
+    self.assertEqual(1, nc.stats['reconnects'])
+    try:
+      yield from nc.flush(2)
+    except ErrTimeout:
+      # If disconnect occurs during this flush, then we will have a timeout here
+      pass
+    finally:
+      yield from nc.close()
+
+    self.assertTrue(disconnected_count >= 1)
+    self.assertTrue(closed_count >= 1)
+
+  @async_test
+  def test_custom_flush_queue_reconnect(self):
+    nc = NATS()
+
+    disconnected_count = 0
+    reconnected_count = 0
+    closed_count = 0
+    err_count = 0
+
+    @asyncio.coroutine
+    def disconnected_cb():
+      nonlocal disconnected_count
+      disconnected_count += 1
+
+    @asyncio.coroutine
+    def reconnected_cb():
+      nonlocal reconnected_count
+      reconnected_count += 1
+
+    @asyncio.coroutine
+    def closed_cb():
+      nonlocal closed_count
+      closed_count += 1
+
+    options = {
+      'servers': [
+        "nats://foo:bar@127.0.0.1:4223",
+        "nats://hoge:fuga@127.0.0.1:4224"
+       ],
+      'dont_randomize': True,
+      'io_loop': self.loop,
+      'disconnected_cb': disconnected_cb,
+      'closed_cb': closed_cb,
+      'reconnected_cb': reconnected_cb,
+      'flusher_queue_size': 100,
+      'reconnect_time_wait': 0.01
+      }
+    yield from nc.connect(**options)
+    largest_pending_data_size = 0
+    post_flush_pending_data = None
+    done_once = False
+
+    @asyncio.coroutine
+    def cb(msg):
+      pass
+
+    yield from nc.subscribe("example.*", cb=cb)
+
+    for i in range(0,500):
+      yield from nc.publish("example.{}".format(i), b'A' * 20)
+      if nc.pending_data_size > 0:
+        largest_pending_data_size = nc.pending_data_size
+      if nc.pending_data_size > 100:
+        # Stop the first server and connect to another one asap.
+        if not done_once:
+          yield from nc.flush(2)
+          post_flush_pending_data = nc.pending_data_size
+          yield from self.loop.run_in_executor(None, self.server_pool[0].stop)
+          done_once = True
+
+    self.assertTrue(largest_pending_data_size > 0)
+    self.assertTrue(post_flush_pending_data == 0)
+
+    # Confirm we have reconnected eventually
+    for i in range(0, 10):
+      yield from asyncio.sleep(0, loop=self.loop)
+      yield from asyncio.sleep(0.2, loop=self.loop)
+      yield from asyncio.sleep(0, loop=self.loop)
+    self.assertEqual(1, nc.stats['reconnects'])
     try:
       yield from nc.flush(2)
     except ErrTimeout:

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -659,7 +659,7 @@ class ClientReconnectTest(MultiServerAuthTestCase):
     self.assertEqual(1, closed_count)
     self.assertEqual(2, disconnected_count)
     self.assertEqual(1, reconnected_count)
-    self.assertEqual(0, err_count)
+    self.assertEqual(1, err_count)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Allow customizing pending flusher via `flusher_queue_size`
- Cancel tasks on reconnection attempt and restart flusher flusher there
- Remove usage of `queue.task_done()` and just cancel task