### PR TITLE
Add support for auth token

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ python:
   - 3.5.1
   - 3.6
 
-env:
-  - DEBUG_NATS_TEST=true
-
 before_install:
   - bash ./script/install_gnatsd.sh
 

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -689,8 +689,13 @@ class Client(object):
         }
         if "auth_required" in self._server_info:
             if self._server_info["auth_required"]:
-                options["user"] = self._current_server.uri.username
-                options["pass"] = self._current_server.uri.password
+                # In case there is no password, then consider handle
+                # sending a token instead.
+                if self._current_server.uri.password is None:
+                    options["auth_token"] = self._current_server.uri.username
+                else:
+                    options["user"] = self._current_server.uri.username
+                    options["pass"] = self._current_server.uri.password
         if self.options["name"] is not None:
             options["name"] = self.options["name"]
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -13,6 +13,7 @@ if __name__ == '__main__':
     test_suite.addTest(unittest.makeSuite(ClientUtilsTest))
     test_suite.addTest(unittest.makeSuite(ClientTest))
     test_suite.addTest(unittest.makeSuite(ClientReconnectTest))
+    test_suite.addTest(unittest.makeSuite(ClientAuthTokenTest))
     test_suite.addTest(unittest.makeSuite(ClientTLSTest))
     test_suite.addTest(unittest.makeSuite(ClientTLSReconnectTest))
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -14,6 +14,7 @@ class Gnatsd(object):
                port=4222,
                user="",
                password="",
+               token="",
                timeout=0,
                http_port=8222,
                debug=False,
@@ -27,6 +28,7 @@ class Gnatsd(object):
     self.proc = None
     self.debug = debug
     self.tls = tls
+    self.token = token
 
     env_debug_flag = os.environ.get("DEBUG_NATS_TEST")
     if env_debug_flag == "true":
@@ -40,6 +42,10 @@ class Gnatsd(object):
     if self.password != "":
       cmd.append("--pass")
       cmd.append(self.password)
+
+    if self.token != "":
+      cmd.append("--auth")
+      cmd.append(self.token)
 
     if self.debug:
       cmd.append("-DV")
@@ -120,6 +126,28 @@ class MultiServerAuthTestCase(NatsTestCase):
     self.server_pool.append(server1)
     server2 = Gnatsd(port=4224, user="hoge", password="fuga", http_port=8224)
     self.server_pool.append(server2)
+    for gnatsd in self.server_pool:
+      start_gnatsd(gnatsd)
+
+  def tearDown(self):
+    for gnatsd in self.server_pool:
+      gnatsd.stop()
+    self.loop.close()
+
+class MultiServerAuthTokenTestCase(NatsTestCase):
+
+  def setUp(self):
+    super(MultiServerAuthTokenTestCase, self).setUp()
+    self.server_pool = []
+    self.loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(None)
+
+    server1 = Gnatsd(port=4223, token="token", http_port=8223)
+    self.server_pool.append(server1)
+    server2 = Gnatsd(port=4224, token="token", http_port=8224)
+    self.server_pool.append(server2)
+    server3 = Gnatsd(port=4225, token="secret", http_port=8225)
+    self.server_pool.append(server3)
     for gnatsd in self.server_pool:
       start_gnatsd(gnatsd)
 


### PR DESCRIPTION
Enable passing an auth token to the server on `CONNECT` by setting it as part of the URI from a server.

```python
options = {
  'servers': [
      'nats://token@127.0.0.1:4223'
   ]
}
yield from nc.connect(**options)
```

Fixes #37