### PR TITLE
Raise error if response from server is empty

### DIFF
--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -831,6 +831,8 @@ class Client(object):
 
         # FIXME: Add readline timeout
         info_line = yield from self._io_reader.readline()
+        if info_line == '':
+            raise NatsError("nats: empty response from server when expecting INFO message")
         _, info = info_line.split(INFO_OP + _SPC_, 1)
         srv_info = json.loads(info.decode())
         self._process_info(srv_info)


### PR DESCRIPTION
Sometimes when opening a new connection to the server (after shuting down
the server) an empty response is received, but an INFO message
was expected.

https://github.com/nats-io/asyncio-nats/blob/d1c1ac56bf9b1ee11aa272f51425eceb0be762a1/nats/aio/client.py#L834

If `info_line` is empty then an error like the following is raised:

```
not enough values to unpack (expected 2, got 1)
```

Steps to reproduce:

1) Having a client to publish to nats
2) Having a server to listen from nats
3) Set `reconnect_time_wait = 1` on the server script
4) Start nats server, client and server scripts
5) Shutdown nats server
6) Sometimes the error is raised