### PR TITLE
fixup reconnect: raise `NatsError` on empty server info response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ var
 sdist
 develop-eggs
 .installed.cfg
+
+.vscode

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -831,6 +831,9 @@ class Client(object):
 
         # FIXME: Add readline timeout
         info_line = yield from self._io_reader.readline()
+        if not info_line:
+            raise NatsError('unable to get server info')
+
         _, info = info_line.split(INFO_OP + _SPC_, 1)
         srv_info = json.loads(info.decode())
         self._process_info(srv_info)


### PR DESCRIPTION
Hi!

Here is a small fix for reconnect logic. @wallyqs what do you think about fix? Or maybe you know a better solution?

Best regards.