### PR TITLE
Process connect init fixes

### DIFF
--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -193,6 +193,11 @@ class Client(object):
                 self._err = e
                 if self._error_cb is not None:
                     yield from self._error_cb(e)
+
+                # Bail on first attempt if reconnecting is disallowed.
+                if not self.options["allow_reconnect"]:
+                    raise e
+
                 yield from self._close(Client.DISCONNECTED, False)
                 self._current_server.last_attempt = time.monotonic()
                 self._current_server.reconnects += 1

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -831,6 +831,8 @@ class Client(object):
 
         # FIXME: Add readline timeout
         info_line = yield from self._io_reader.readline()
+        if not info_line:
+            raise NatsError("nats: empty response from server when expecting INFO message")
         _, info = info_line.split(INFO_OP + _SPC_, 1)
         srv_info = json.loads(info.decode())
         self._process_info(srv_info)
@@ -842,13 +844,13 @@ class Client(object):
         if 'tls_required' in self._server_info and self._server_info['tls_required']:
             ssl_context = self.options.get('tls')
             if not ssl_context:
-                raise NatsError('no ssl context provided')
+                raise NatsError('nats: no ssl context provided')
 
             transport = self._io_writer.transport
             sock = transport.get_extra_info('socket')
             if not sock:
                 # This shouldn't happen
-                raise NatsError('unable to get socket')
+                raise NatsError('nats: unable to get socket')
             yield from self._io_writer.drain()  # just in case something is left
 
             self._io_reader, self._io_writer = \

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -834,10 +834,12 @@ class Client(object):
         _, info = info_line.split(INFO_OP + _SPC_, 1)
         srv_info = json.loads(info.decode())
         self._process_info(srv_info)
-
         self._server_info = srv_info
-        self._max_payload = self._server_info["max_payload"]
-        if self._server_info['tls_required']:
+
+        if 'max_payload' in self._server_info:
+            self._max_payload = self._server_info["max_payload"]
+
+        if 'tls_required' in self._server_info and self._server_info['tls_required']:
             ssl_context = self.options.get('tls')
             if not ssl_context:
                 raise NatsError('no ssl context provided')

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -836,11 +836,16 @@ class Client(object):
 
         # FIXME: Add readline timeout
         info_line = yield from self._io_reader.readline()
-        if not info_line:
+        if INFO_OP not in info_line:
             raise NatsError("nats: empty response from server when expecting INFO message")
 
         _, info = info_line.split(INFO_OP + _SPC_, 1)
-        srv_info = json.loads(info.decode())
+
+        try:
+            srv_info = json.loads(info.decode())
+        except:
+            raise NatsError("nats: info message, json parse error")
+
         self._process_info(srv_info)
         self._server_info = srv_info
 

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -838,6 +838,7 @@ class Client(object):
         info_line = yield from self._io_reader.readline()
         if not info_line:
             raise NatsError("nats: empty response from server when expecting INFO message")
+
         _, info = info_line.split(INFO_OP + _SPC_, 1)
         srv_info = json.loads(info.decode())
         self._process_info(srv_info)

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -1111,6 +1111,86 @@ class ClusterDiscoveryTest(ClusteringTestCase):
         self.assertEqual(len(nc.servers), 3)
         self.assertEqual(len(nc.discovered_servers), 2)
 
+class ConnectFailuresTest(SingleServerTestCase):
+
+    @async_test
+    def test_empty_info_op_uses_defaults(self):
+
+        @asyncio.coroutine
+        def bad_server(reader, writer):
+            writer.write(b'INFO {}\r\n')
+            yield from writer.drain()
+
+            data = yield from reader.readline()
+            yield from asyncio.sleep(0.2, loop=self.loop)
+            writer.close()
+
+        yield from asyncio.start_server(
+            bad_server,
+            '127.0.0.1',
+            4555,
+            loop=self.loop
+            )
+
+        disconnected_count = 0
+
+        @asyncio.coroutine
+        def disconnected_cb():
+            nonlocal disconnected_count
+            disconnected_count += 1
+
+        nc = NATS()
+        options = {
+            'servers': [
+                "nats://127.0.0.1:4555",
+                ],
+            'disconnected_cb': disconnected_cb,
+            'io_loop': self.loop
+            }
+        yield from nc.connect(**options)
+        self.assertEqual(nc.max_payload, 1048576)
+
+        yield from nc.close()
+        self.assertEqual(1, disconnected_count)
+
+    @async_test
+    def test_empty_response_from_server(self):
+
+        @asyncio.coroutine
+        def bad_server(reader, writer):
+            writer.write(b'')
+            yield from asyncio.sleep(0.2, loop=self.loop)
+            writer.close()
+
+        yield from asyncio.start_server(
+            bad_server,
+            '127.0.0.1',
+            4555,
+            loop=self.loop
+            )
+
+        errors = []
+
+        @asyncio.coroutine
+        def error_cb(e):
+            nonlocal errors
+            errors.append(e)
+
+        nc = NATS()
+        options = {
+            'servers': [
+                "nats://127.0.0.1:4555",
+                ],
+            'error_cb': error_cb,
+            'io_loop': self.loop,
+            'allow_reconnect': False,
+            }
+
+        with self.assertRaises(NatsError):
+            yield from nc.connect(**options)
+        self.assertEqual(1, len(errors))            
+        self.assertEqual(errors[0], nc.last_error)
+
 if __name__ == '__main__':
     runner = unittest.TextTestRunner(stream=sys.stdout)
     unittest.main(verbosity=2, exit=False, testRunner=runner)

--- a/tests/test.py
+++ b/tests/test.py
@@ -16,6 +16,7 @@ if __name__ == '__main__':
     test_suite.addTest(unittest.makeSuite(ClientAuthTokenTest))
     test_suite.addTest(unittest.makeSuite(ClientTLSTest))
     test_suite.addTest(unittest.makeSuite(ClientTLSReconnectTest))
+    test_suite.addTest(unittest.makeSuite(ConnectFailuresTest))
 
     # Skip tests using async/await syntax unless on Python 3.5
     if sys.version_info >= (3, 5):


### PR DESCRIPTION
- Fix `allow_reconnect` to bail connecting on errors during after first connect
- Fix error handling when server does not respond with properly formed INFO line on connect
- Fix checks for keys in INFO line and use defaults if not present