### PR TITLE
Use Task per Subscription for processing messages

### DIFF
--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -456,6 +456,9 @@ class Client(object):
     def subscribe_async(self, subject, **kwargs):
         """
         Sets the subcription to use a task per message to be processed.
+
+        ..deprecated:: 7.0
+          Will be removed 9.0.
         """
         kwargs["is_async"] = True
         sid = yield from self.subscribe(subject, **kwargs)

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -55,6 +55,10 @@ DEFAULT_MAX_PAYLOAD_SIZE = 1048576
 DEFAULT_MAX_FLUSHER_QUEUE_SIZE = 1024
 MAX_CONTROL_LINE_SIZE = 1024
 
+# Default Pending Limits of Subscriptions
+DEFAULT_SUB_PENDING_MSGS_LIMIT  = 65536
+DEFAULT_SUB_PENDING_BYTES_LIMIT = 65536 * 1024
+
 class Subscription(object):
     def __init__(self, subject='', queue='', future=None, max_msgs=0,
                  is_async=False, cb=None, coro=None):
@@ -67,6 +71,12 @@ class Subscription(object):
         self.cb = cb
         self.coro = coro
 
+        # Per subscription message processor
+        self.pending_msgs_limit = None
+        self.pending_bytes_limit = None
+        self.pending_queue = None
+        self.pending_size = 0
+        self.wait_for_msgs_task = None
 
 class Msg(object):
     def __init__(self, subject='', reply='', data=b'', sid=0):
@@ -74,7 +84,6 @@ class Msg(object):
         self.reply = reply
         self.data = data
         self.sid = sid
-
 
 class Srv(object):
     """
@@ -258,6 +267,10 @@ class Client(object):
 
         # Cleanup subscriptions since not reconnecting so no need
         # to replay the subscriptions anymore.
+        for i, sub in self._subs.items():
+            # FIXME: Should we clear the pending queue here?
+            if sub.wait_for_msgs_task is not None:
+                sub.wait_for_msgs_task.cancel()
         self._subs.clear()
 
         if self._io_writer is not None:
@@ -323,7 +336,15 @@ class Client(object):
             yield from self._flush_pending()
 
     @asyncio.coroutine
-    def subscribe(self, subject, queue="", cb=None, future=None, max_msgs=0, is_async=False):
+    def subscribe(self, subject,
+                  queue="",
+                  cb=None,
+                  future=None,
+                  max_msgs=0,
+                  is_async=False,
+                  pending_msgs_limit=DEFAULT_SUB_PENDING_MSGS_LIMIT,
+                  pending_bytes_limit=DEFAULT_SUB_PENDING_BYTES_LIMIT,
+                  ):
         """
         Takes a subject string and optional queue string to send a SUB cmd,
         and a callback which to which messages (Msg) will be dispatched to
@@ -347,8 +368,70 @@ class Client(object):
                 raise NatsError(
                     "nats: must use coroutine for async subscriptions")
             else:
+                # NOTE: Consider to deprecate this eventually, it should always
+                # be coroutines otherwise they could affect the single thread,
+                # for now still allow to be flexible.
                 sub.cb = cb
+
+            sub.pending_msgs_limit = pending_msgs_limit
+            sub.pending_bytes_limit = pending_bytes_limit
+            sub.pending_queue = asyncio.Queue(
+                maxsize=pending_msgs_limit,
+                loop=self._loop,
+                )
+
+            # Close the delivery coroutine over the sub and error handler
+            # instead of having subscription type hold over state of the conn.
+            err_cb = self._error_cb
+
+            @asyncio.coroutine
+            def wait_for_msgs():
+                nonlocal sub
+                nonlocal err_cb
+
+                while True:
+                    try:
+                        msg = yield from sub.pending_queue.get()
+                        sub.pending_size -= len(msg.data)
+
+                        try:
+                            # Invoke depending of type of handler.
+                            if sub.coro is not None:
+                                if sub.is_async:
+                                    # NOTE: Deprecate this usage in a next release,
+                                    # the handler implementation ought to decide
+                                    # the concurrency level at which the messages
+                                    # should be processed.
+                                    self._loop.create_task(sub.coro(msg))
+                                else:
+                                    yield from sub.coro(msg)
+                            elif sub.cb is not None:
+                                if sub.is_async:
+                                    raise NatsError(
+                                        "nats: must use coroutine for async subscriptions")
+                                else:
+                                    # Schedule regular callbacks to be processed sequentially.
+                                    self._loop.call_soon(sub.cb, msg)
+                        except asyncio.CancelledError:
+                            # In case the coroutine handler gets cancelled
+                            # then stop task loop and return.
+                            break
+                        except Exception as e:
+                            # All errors from calling a handler
+                            # are async errors.
+                            if err_cb is not None:
+                                yield from err_cb(e)
+
+                    except asyncio.CancelledError:
+                        break
+
+            # Start task for each subscription, it should be cancelled
+            # on both unsubscribe and closing as well.
+            sub.wait_for_msgs_task = self._loop.create_task(
+                wait_for_msgs())
+
         elif future is not None:
+            # Used to handle the single response from a request.
             sub.future = future
         else:
             raise NatsError("nats: invalid subscription type")
@@ -362,7 +445,7 @@ class Client(object):
     @asyncio.coroutine
     def subscribe_async(self, subject, **kwargs):
         """
-        Sets the subcription to use a task when processing dispatched messages.
+        Sets the subcription to use a task per message to be processed.
         """
         kwargs["is_async"] = True
         sid = yield from self.subscribe(subject, **kwargs)
@@ -389,6 +472,10 @@ class Client(object):
         # remove the callback locally too.
         if max_msgs == 0 or sub.received >= max_msgs:
             self._subs.pop(ssid, None)
+
+        # Cancel task from subscription if present.
+        if sub.wait_for_msgs_task is not None:
+            sub.wait_for_msgs_task.cancel()
 
         # We will send these for all subs when we reconnect anyway,
         # so that we can suppress here.
@@ -787,8 +874,9 @@ class Client(object):
         """
         Process MSG sent by server.
         """
+        payload_size = len(data)
         self.stats['in_msgs'] += 1
-        self.stats['in_bytes'] += len(data)
+        self.stats['in_bytes'] += payload_size
 
         sub = self._subs.get(sid)
         if sub is None:
@@ -799,26 +887,25 @@ class Client(object):
         if sub.max_msgs > 0 and sub.received >= sub.max_msgs:
             # Enough messages so can throwaway subscription now.
             self._subs.pop(sid, None)
-
         msg = self._build_message(subject, reply, data)
-        if sub.coro is not None:
-            if sub.is_async:
-                # Dispatch each one of the coroutines using a task
-                # to run them asynchronously.
-                self._loop.create_task(sub.coro(msg))
-            else:
-                # Await for the result each coroutine at a time
-                # and process sequentially.
-                yield from sub.coro(msg)
-        elif sub.cb is not None:
-            if sub.is_async:
-                raise NatsError(
-                    "nats: must use coroutine for async subscriptions")
-            else:
-                # Schedule regular callbacks to be processed sequentially.
-                self._loop.call_soon(sub.cb, msg)
-        elif sub.future is not None and not sub.future.cancelled():
+
+        # Check if it is an old style request.
+        if sub.future is not None:
+            if sub.future.cancelled():
+                # Already gave up, nothing to do.
+                return
             sub.future.set_result(msg)
+            return
+
+        # Let subscription wait_for_msgs coroutine process the messages,
+        # but in case sending to the subscription task would block,
+        # then consider it to be an slow consumer and drop the message.
+        try:
+            sub.pending_size += payload_size
+            sub.pending_queue.put_nowait(msg)
+        except asyncio.QueueFull:
+            if self._error_cb is not None:
+                yield from self._error_cb(ErrSlowConsumer)
 
     def _build_message(self, subject, reply, data):
         return self.msg_class(subject=subject.decode(), reply=reply.decode(),

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -79,11 +79,21 @@ class Subscription(object):
         self.wait_for_msgs_task = None
 
 class Msg(object):
+    __slots__ = ('subject', 'reply', 'data', 'sid')
+
     def __init__(self, subject='', reply='', data=b'', sid=0):
         self.subject = subject
         self.reply = reply
         self.data = data
         self.sid = sid
+
+    def __repr__(self):
+        return "<{}: subject='{}' reply='{}' data='{}...'>".format(
+            self.__class__.__name__,
+            self.subject,
+            self.reply,
+            self.data[:10].decode(),
+            )
 
 class Srv(object):
     """

--- a/nats/aio/errors.py
+++ b/nats/aio/errors.py
@@ -53,9 +53,12 @@ class ErrBadSubject(NatsError):
 
 
 class ErrSlowConsumer(NatsError):
+    def __init__(self, subject=None, sid=None):
+        self.subject = subject
+        self.sid = sid
+
     def __str__(self):
         return "nats: Slow Consumer, messages dropped"
-
 
 class ErrTimeout(asyncio.TimeoutError):
     def __str__(self):

--- a/tests/client_async_await_test.py
+++ b/tests/client_async_await_test.py
@@ -3,8 +3,8 @@ import asyncio
 import unittest
 
 from nats.aio.client import Client as NATS
+from nats.aio.errors import ErrTimeout, ErrSlowConsumer
 from tests.utils import (async_test, SingleServerTestCase)
-
 
 class ClientAsyncAwaitTest(SingleServerTestCase):
 
@@ -58,6 +58,158 @@ class ClientAsyncAwaitTest(SingleServerTestCase):
         self.assertEqual("tests.3", msgs[3].subject)
         yield from nc.close()
 
+    @async_test
+    def test_async_await_messages_delivery_order(self):
+        nc = NATS()
+        msgs = []
+        errors = []
+
+        async def error_handler(e):
+            errors.push(e)
+
+        yield from nc.connect(io_loop=self.loop, error_cb=error_handler)
+
+        @asyncio.coroutine
+        def handler_foo(msg):
+          msgs.append(msg)
+
+          # Should not block other subscriptions from receiving messages.
+          yield from asyncio.sleep(0.2, loop=self.loop)
+          if msg.reply != "":
+            yield from nc.publish(msg.reply, msg.data*2)
+        yield from nc.subscribe("foo", cb=handler_foo)
+
+        async def handler_bar(msg):
+          msgs.append(msg)
+          if msg.reply != "":
+            await nc.publish(msg.reply, b'')
+        yield from nc.subscribe("bar", cb=handler_bar)
+
+        yield from nc.publish("foo", b'1')
+        yield from nc.publish("foo", b'2')
+        yield from nc.publish("foo", b'3')
+
+        # Will be processed before the others since no head of line
+        # blocking among the subscriptions.
+        yield from nc.publish("bar", b'4')
+
+        response = yield from nc.timed_request("foo", b'hello1', 1)
+        self.assertEqual(response.data, b'hello1hello1')
+
+        with self.assertRaises(ErrTimeout):
+            yield from nc.timed_request("foo", b'hello2', 0.1)
+
+        yield from nc.publish("bar", b'5')
+        response = yield from nc.timed_request("foo", b'hello2', 1)
+        self.assertEqual(response.data, b'hello2hello2')
+
+        self.assertEqual(msgs[0].data, b'1')
+        self.assertEqual(msgs[1].data, b'4')
+        self.assertEqual(msgs[2].data, b'2')
+        self.assertEqual(msgs[3].data, b'3')
+        self.assertEqual(msgs[4].data, b'hello1')
+        self.assertEqual(msgs[5].data, b'hello2')
+        self.assertEqual(len(errors), 0)
+        yield from nc.close()
+
+    @async_test
+    def test_subscription_slow_consumer_pending_msg_limit(self):
+        nc = NATS()
+        msgs = []
+        errors = []
+
+        async def error_handler(e):
+            if type(e) is ErrSlowConsumer:
+                errors.append(e)
+
+        yield from nc.connect(io_loop=self.loop, error_cb=error_handler)
+
+        @asyncio.coroutine
+        def handler_foo(msg):
+          yield from asyncio.sleep(0.2, loop=self.loop)
+
+          msgs.append(msg)
+          if msg.reply != "":
+            yield from nc.publish(msg.reply, msg.data*2)
+        yield from nc.subscribe("foo", cb=handler_foo, pending_msgs_limit=5)
+
+        async def handler_bar(msg):
+          msgs.append(msg)
+          if msg.reply != "":
+            await nc.publish(msg.reply, msg.data*3)
+        yield from nc.subscribe("bar", cb=handler_bar)
+
+        for i in range(10):
+            yield from nc.publish("foo", '{}'.format(i).encode())
+
+        # Will be processed before the others since no head of line
+        # blocking among the subscriptions.
+        yield from nc.publish("bar", b'14')
+        response = yield from nc.timed_request("bar", b'hi1', 2)
+        self.assertEqual(response.data, b'hi1hi1hi1')
+
+        self.assertEqual(len(msgs), 2)
+        self.assertEqual(msgs[0].data, b'14')
+        self.assertEqual(msgs[1].data, b'hi1')
+
+        # Consumed messages but the rest were slow consumers.
+        self.assertTrue(4 <= len(errors) <= 5)
+        for e in errors:
+            self.assertEqual(type(e), ErrSlowConsumer)
+        self.assertEqual(errors[0].sid, 1)
+        yield from nc.close()
+
+    @async_test
+    def test_subscription_slow_consumer_pending_bytes_limit(self):
+        nc = NATS()
+        msgs = []
+        errors = []
+
+        async def error_handler(e):
+            if type(e) is ErrSlowConsumer:
+                errors.append(e)
+
+        yield from nc.connect(io_loop=self.loop, error_cb=error_handler)
+
+        @asyncio.coroutine
+        def handler_foo(msg):
+            yield from asyncio.sleep(0.2, loop=self.loop)
+
+            msgs.append(msg)
+            if msg.reply != "":
+                yield from nc.publish(msg.reply, msg.data*2)
+        yield from nc.subscribe("foo", cb=handler_foo, pending_bytes_limit=10)
+
+        async def handler_bar(msg):
+            msgs.append(msg)
+            if msg.reply != "":
+                await nc.publish(msg.reply, msg.data*3)
+        yield from nc.subscribe("bar", cb=handler_bar)
+
+        for i in range(10):
+            yield from nc.publish("foo", "AAA{}".format(i).encode())
+
+        # Will be processed before the others since no head of line
+        # blocking among the subscriptions.
+        yield from nc.publish("bar", b'14')
+
+        response = yield from nc.timed_request("bar", b'hi1', 2)
+        self.assertEqual(response.data, b'hi1hi1hi1')
+        self.assertEqual(len(msgs), 2)
+        self.assertEqual(msgs[0].data, b'14')
+        self.assertEqual(msgs[1].data, b'hi1')
+
+        # Consumed a few messages but the rest were slow consumers.
+        self.assertTrue(7 <= len(errors) <= 8)
+        for e in errors:
+            self.assertEqual(type(e), ErrSlowConsumer)
+        self.assertEqual(errors[0].sid, 1)
+
+        # Try again a few seconds later and it should have recovered
+        yield from asyncio.sleep(3, loop=self.loop)
+        response = yield from nc.timed_request("foo", b'B', 1)
+        self.assertEqual(response.data, b'BB')
+        yield from nc.close()
 
 if __name__ == '__main__':
     runner = unittest.TextTestRunner(stream=sys.stdout)


### PR DESCRIPTION
Currently when having multiple subscriptions processing messages, unless `subscribe_async` is used which creates a task per message, then a single coroutine would be able to block other coroutines from processing messages. 

In the next release, this behavior is changed to instead have a single task per subscription that is processing the messages using a sized `asyncio.Queue` per subscription as well in order to not have a single coroutine block others from being scheduled, which is similar behavior as in the Go client.  This also adds `sid` and `subject` to the `ErrSlowconsumer` error which is now invoked whenever the library drops a message when the queue is full.


