### PR TITLE
Python3.7 updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,10 @@ notifications:
 
 sudo: false
 dist: trusty
+
+# Temporary for Python 3.7
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true

--- a/readme.md
+++ b/readme.md
@@ -350,7 +350,6 @@ TLS connections can be configured with an [ssl context](https://docs.python.org/
 
 ```python
 ssl_ctx = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH)
-ssl_ctx.protocol = ssl.PROTOCOL_TLSv1_2
 ssl_ctx.load_verify_locations('ca.pem')
 ssl_ctx.load_cert_chain(certfile='client-cert.pem',
                         keyfile='client-key.pem')

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -1183,6 +1183,7 @@ class ClientTLSTest(TLSServerTestCase):
 
 class ClientTLSReconnectTest(MultiTLSServerAuthTestCase):
 
+    @asyncio.coroutine
     @async_test
     def test_tls_reconnect(self):
 

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -70,6 +70,7 @@ class ClientTest(SingleServerTestCase):
                                   reconnect_time_wait=0.2,
                                   )
 
+    @asyncio.coroutine
     @async_test
     def test_publish(self):
         nc = NATS()
@@ -95,6 +96,7 @@ class ClientTest(SingleServerTestCase):
         self.assertEqual(100, varz['in_msgs'])
         self.assertEqual(100, varz['in_bytes'])
 
+    @asyncio.coroutine
     @async_test
     def test_flush(self):
         nc = NATS()
@@ -106,6 +108,7 @@ class ClientTest(SingleServerTestCase):
         self.assertEqual(20, nc.stats['out_bytes'])
         yield from nc.close()
 
+    @asyncio.coroutine
     @async_test
     def test_subscribe(self):
         nc = NATS()
@@ -156,6 +159,7 @@ class ClientTest(SingleServerTestCase):
         self.assertEqual(1,  connz['connections'][0]['out_msgs'])
         self.assertEqual(11, connz['connections'][0]['out_bytes'])
 
+    @asyncio.coroutine
     @async_test
     def test_invalid_subscribe_error(self):
         nc = NATS()
@@ -178,6 +182,7 @@ class ClientTest(SingleServerTestCase):
         self.assertEqual(type(nats_error), NatsError)
         self.assertEqual(str(nats_error), "nats: 'Invalid Subject'")
 
+    @asyncio.coroutine
     @async_test
     def test_subscribe_async(self):
         nc = NATS()
@@ -204,6 +209,7 @@ class ClientTest(SingleServerTestCase):
         self.assertEqual("tests.3", msgs[3].subject)
         yield from nc.close()
 
+    @asyncio.coroutine
     @async_test
     def test_subscribe_sync(self):
         nc = NATS()
@@ -230,6 +236,7 @@ class ClientTest(SingleServerTestCase):
         self.assertEqual("tests.3", msgs[3].subject)
         yield from nc.close()
 
+    @asyncio.coroutine
     @async_test
     def test_subscribe_sync_call_soon(self):
         nc = NATS()
@@ -271,6 +278,7 @@ class ClientTest(SingleServerTestCase):
             sid = yield from nc.subscribe_async("tests.>", cb=subscription_handler)
         yield from nc.close()
 
+    @asyncio.coroutine
     @async_test
     def test_invalid_subscription_type(self):
         nc = NATS()
@@ -281,6 +289,7 @@ class ClientTest(SingleServerTestCase):
         with self.assertRaises(NatsError):
             yield from nc.subscribe_async("hello", cb=None)
 
+    @asyncio.coroutine
     @async_test
     def test_unsubscribe(self):
         nc = NATS()
@@ -330,6 +339,7 @@ class ClientTest(SingleServerTestCase):
         self.assertEqual(4, nc.stats['out_msgs'])
         self.assertEqual(4, nc.stats['out_bytes'])
 
+    @asyncio.coroutine
     @async_test
     def test_timed_request(self):
         nc = NATS()
@@ -362,6 +372,7 @@ class ClientTest(SingleServerTestCase):
         yield from asyncio.sleep(1, loop=self.loop)
         yield from nc.close()
 
+    @asyncio.coroutine
     @async_test
     def test_new_style_request(self):
         nc = NATS()
@@ -463,6 +474,7 @@ class ClientTest(SingleServerTestCase):
         self.assertEqual(0, reconnected_count)
         self.assertEqual(0, err_count)
 
+    @asyncio.coroutine
     @async_test
     def test_pending_data_size_flush_on_close(self):
         nc = NATS()
@@ -571,6 +583,7 @@ class ClientReconnectTest(MultiServerAuthTestCase):
         self.assertEqual(ErrNoServers, type(nc.last_error))
         self.assertEqual(0, nc.stats['reconnects'])
 
+    @asyncio.coroutine
     @async_test
     def test_infinite_reconnect(self):
         nc = NATS()
@@ -636,6 +649,7 @@ class ClientReconnectTest(MultiServerAuthTestCase):
         self.assertTrue(nc.is_closed)
         self.assertEqual(ConnectionRefusedError, type(nc.last_error))
 
+    @asyncio.coroutine
     @async_test
     def test_failed_reconnect_removes_servers(self):
         nc = NATS()
@@ -776,6 +790,7 @@ class ClientReconnectTest(MultiServerAuthTestCase):
                 pending_tasks_count += 1
         self.assertEqual(expected_tasks, pending_tasks_count)
 
+    @asyncio.coroutine
     @async_test
     def test_pending_data_size_flush_reconnect(self):
         nc = NATS()
@@ -855,6 +870,7 @@ class ClientReconnectTest(MultiServerAuthTestCase):
         self.assertTrue(disconnected_count >= 1)
         self.assertTrue(closed_count >= 1)
 
+    @asyncio.coroutine
     @async_test
     def test_custom_flush_queue_reconnect(self):
         nc = NATS()
@@ -935,6 +951,7 @@ class ClientReconnectTest(MultiServerAuthTestCase):
         self.assertTrue(disconnected_count >= 1)
         self.assertTrue(closed_count >= 1)
 
+    @asyncio.coroutine
     @async_test
     def test_auth_reconnect(self):
         nc = NATS()
@@ -1050,6 +1067,7 @@ class ClientAuthTokenTest(MultiServerAuthTokenTestCase):
         self.assertIn('auth_required', nc._server_info)
         self.assertFalse(nc.is_connected)
 
+    @asyncio.coroutine
     @async_test
     def test_reconnect_with_auth_token(self):
         nc = NATS()

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -1310,6 +1310,7 @@ class ClusterDiscoveryTest(ClusteringTestCase):
 
 class ConnectFailuresTest(SingleServerTestCase):
 
+    @asyncio.coroutine
     @async_test
     def test_empty_info_op_uses_defaults(self):
 
@@ -1350,6 +1351,7 @@ class ConnectFailuresTest(SingleServerTestCase):
         yield from nc.close()
         self.assertEqual(1, disconnected_count)
 
+    @asyncio.coroutine
     @async_test
     def test_empty_response_from_server(self):
 
@@ -1388,6 +1390,7 @@ class ConnectFailuresTest(SingleServerTestCase):
         self.assertEqual(1, len(errors))            
         self.assertEqual(errors[0], nc.last_error)
 
+    @asyncio.coroutine
     @async_test
     def test_malformed_info_response_from_server(self):
 
@@ -1426,6 +1429,7 @@ class ConnectFailuresTest(SingleServerTestCase):
         self.assertEqual(1, len(errors))            
         self.assertEqual(errors[0], nc.last_error)
 
+    @asyncio.coroutine
     @async_test
     def test_malformed_info_json_response_from_server(self):
 

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -1149,6 +1149,7 @@ class ClientTLSTest(TLSServerTestCase):
         self.assertTrue(nc.is_closed)
         self.assertFalse(nc.is_connected)
 
+    @asyncio.coroutine
     @async_test
     def test_subscribe(self):
         nc = NATS()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -196,7 +196,7 @@ class TLSServerTestCase(NatsTestCase):
 
         self.ssl_ctx = ssl.create_default_context(
             purpose=ssl.Purpose.SERVER_AUTH)
-        self.ssl_ctx.protocol = ssl.PROTOCOL_TLSv1_2
+        # self.ssl_ctx.protocol = ssl.PROTOCOL_TLSv1_2
         self.ssl_ctx.load_verify_locations('tests/certs/ca.pem')
         self.ssl_ctx.load_cert_chain(certfile='tests/certs/client-cert.pem',
                                      keyfile='tests/certs/client-key.pem')

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -225,7 +225,7 @@ class MultiTLSServerAuthTestCase(NatsTestCase):
 
         self.ssl_ctx = ssl.create_default_context(
             purpose=ssl.Purpose.SERVER_AUTH)
-        self.ssl_ctx.protocol = ssl.PROTOCOL_TLSv1_2
+        # self.ssl_ctx.protocol = ssl.PROTOCOL_TLSv1_2
         self.ssl_ctx.load_verify_locations('tests/certs/ca.pem')
         self.ssl_ctx.load_cert_chain(certfile='tests/certs/client-cert.pem',
                                      keyfile='tests/certs/client-key.pem')


### PR DESCRIPTION
- Adds Python 3.7 to the build using a matrix workaround for now before https://github.com/travis-ci/travis-ci/issues/9815 is solved.
- Fixes the tests that were failing in Python 3.7 with errors duet to `yield from` usage
- Update TLS examples that were not working now due to Python 3.7 changes

Fixes #71 #70 