### PR TITLE
Setup default TLS context when scheme is 'tls'

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -292,7 +292,32 @@ ssl_ctx = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH)
 ssl_ctx.load_verify_locations('ca.pem')
 ssl_ctx.load_cert_chain(certfile='client-cert.pem',
                         keyfile='client-key.pem')
-await nc.connect(loop=loop, tls=ssl_ctx)
+await nc.connect(servers=["tls://127.0.0.1:4443"], loop=loop, tls=ssl_ctx)
+```
+
+Setting the scheme to `tls` in the connect URL will make the client create a [default ssl context](https://docs.python.org/3/library/ssl.html#ssl.create_default_context) automatically:
+
+```python
+import asyncio
+import ssl
+from nats.aio.client import Client as NATS
+
+async def run(loop):
+    nc = NATS()
+    await nc.connect("tls://demo.nats.io:4443", loop=loop)
+```
+
+*Note*: If getting SSL certificate errors in OS X, try first installing the `certifi` certificate bundle. If using Python 3.7 for example, then run:
+
+```
+$ /Applications/Python\ 3.7/Install\ Certificates.command
+ -- pip install --upgrade certifi
+Collecting certifi
+...
+ -- removing any existing file or link
+ -- creating symlink to certifi certificate bundle
+ -- setting permissions
+ -- update complete
 ```
 
 ## License

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -1264,6 +1264,22 @@ class ClientTLSTest(TLSServerTestCase):
         self.assertFalse(nc.is_connected)
 
     @async_test
+    async def test_default_connect_using_tls_scheme(self):
+        nc = NATS()
+
+        # Will attempt to connect using TLS with default certs.
+        with self.assertRaises(ssl.SSLError):
+            await nc.connect(loop=self.loop, servers=['tls://localhost:4224'], allow_reconnect=False)
+
+    @async_test
+    async def test_default_connect_using_tls_scheme_in_url(self):
+        nc = NATS()
+
+        # Will attempt to connect using TLS with default certs.
+        with self.assertRaises(ssl.SSLError):
+            await nc.connect('tls://localhost:4224', allow_reconnect=False, loop=self.loop)
+
+    @async_test
     async def test_subscribe(self):
         nc = NATS()
         msgs = []


### PR DESCRIPTION
Allow clients to be able to connect to a NATS server securely by only setting `tls` as the scheme:

```
$ python3.7 examples/nats-pub -s tls://demo.nats.io:4443 hello -d world
...

$ python3.7 examples/nats-sub -s tls://demo.nats.io:4443 hello 
Connected to NATS at demo.nats.io:4443...
Received a message on 'hello ': world
```

Also added instructions for OS X users which in Python 3.6 need to first run install the default certs via the `certifi` package:

```sh
# Python 3.6
$ /Applications/Python\ 3.6/Install\ Certificates.command 

# Python 3.7
$ /Applications/Python\ 3.7/Install\ Certificates.command 
```
